### PR TITLE
Gitignorefixes: Ignore VS2008 project files and generated qt moc/ui files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,12 @@
 *.sln
 *.vcxproj
 *.vcxproj.filters
+*.vcproj
 *.sdf
 *.opensdf
+
+moc_*.cxx*
+ui_*.h
 
 *.o
 


### PR DESCRIPTION
Additionally does the deploy.bat really need to copy moc_ and ui_ files to include? I think ui_*.h might be needed if they are included in the headers in your widgets (if they are exported for use) but moc id think is not needed?
